### PR TITLE
Create a deck

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@eslint/js": "^9.19.0",
     "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@types/jest": "^29.5.14",
     "@types/react": "^19.0.8",

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -36,3 +36,18 @@ test("loads decks from local storage on component mount", () => {
   render(<App />);
   expect(screen.getByText("Loaded Deck")).toBeInTheDocument();
 });
+
+test("shows only one deck per tab", () => {
+  const savedDecks = [
+    { deckName: "Deck 1", factions: [] },
+    { deckName: "Deck 2", factions: [] },
+  ];
+  jest.spyOn(localStorage, "getItem").mockReturnValue(JSON.stringify(savedDecks));
+  render(<App />);
+  expect(screen.getByText("Deck 1")).toBeInTheDocument();
+  expect(screen.getByText("Deck 2")).toBeInTheDocument();
+  const tab1 = screen.getByRole("tabpanel", { hidden: true, name: "Deck 1" });
+  const tab2 = screen.getByRole("tabpanel", { hidden: true, name: "Deck 2" });
+  expect(tab1).toBeInTheDocument();
+  expect(tab2).toBeInTheDocument();
+});

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -1,5 +1,10 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import App from "./App";
+import "@testing-library/jest-dom";
+
+window.prompt = jest.fn();
+window.localStorage.__proto__.getItem = jest.fn();
+window.localStorage.__proto__.setItem = jest.fn();
 
 test("renders", () => {
   render(<App />);
@@ -23,16 +28,16 @@ test("saves the deck to local storage", () => {
   fireEvent.click(addButton);
   expect(localStorage.setItem).toHaveBeenCalledWith(
     "decks",
-    JSON.stringify([{ deckName: "Saved Deck", factions: expect.any(Array) }])
+    JSON.stringify([{ deckName: "Saved Deck", factions: expect.any(Array) }]),
   );
   promptSpy.mockRestore();
 });
 
 test("loads decks from local storage on component mount", () => {
-  const savedDecks = [
-    { deckName: "Loaded Deck", factions: [] },
-  ];
-  jest.spyOn(localStorage, "getItem").mockReturnValue(JSON.stringify(savedDecks));
+  const savedDecks = [{ deckName: "Loaded Deck", factions: [] }];
+  jest
+    .spyOn(localStorage, "getItem")
+    .mockReturnValue(JSON.stringify(savedDecks));
   render(<App />);
   expect(screen.getByText("Loaded Deck")).toBeInTheDocument();
 });
@@ -42,7 +47,9 @@ test("shows only one deck per tab", () => {
     { deckName: "Deck 1", factions: [] },
     { deckName: "Deck 2", factions: [] },
   ];
-  jest.spyOn(localStorage, "getItem").mockReturnValue(JSON.stringify(savedDecks));
+  jest
+    .spyOn(localStorage, "getItem")
+    .mockReturnValue(JSON.stringify(savedDecks));
   render(<App />);
   expect(screen.getByText("Deck 1")).toBeInTheDocument();
   expect(screen.getByText("Deck 2")).toBeInTheDocument();

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -1,6 +1,38 @@
-import { render } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import App from "./App";
 
 test("renders", () => {
   render(<App />);
+});
+
+test("creates a new deck with a unique name", () => {
+  render(<App />);
+  const addButton = screen.getByText("Add New Deck");
+  fireEvent.click(addButton);
+  const promptSpy = jest.spyOn(window, "prompt").mockReturnValue("Unique Deck");
+  fireEvent.click(addButton);
+  expect(screen.getByText("Unique Deck")).toBeInTheDocument();
+  promptSpy.mockRestore();
+});
+
+test("saves the deck to local storage", () => {
+  render(<App />);
+  const addButton = screen.getByText("Add New Deck");
+  fireEvent.click(addButton);
+  const promptSpy = jest.spyOn(window, "prompt").mockReturnValue("Saved Deck");
+  fireEvent.click(addButton);
+  expect(localStorage.setItem).toHaveBeenCalledWith(
+    "decks",
+    JSON.stringify([{ deckName: "Saved Deck", factions: expect.any(Array) }])
+  );
+  promptSpy.mockRestore();
+});
+
+test("loads decks from local storage on component mount", () => {
+  const savedDecks = [
+    { deckName: "Loaded Deck", factions: [] },
+  ];
+  jest.spyOn(localStorage, "getItem").mockReturnValue(JSON.stringify(savedDecks));
+  render(<App />);
+  expect(screen.getByText("Loaded Deck")).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ const App: React.FC = () => {
     localStorage.setItem("decks", JSON.stringify(updatedDecks));
   };
 
-  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+  const handleChange = (_event: React.SyntheticEvent, newValue: number) => {
     setSelectedTab(newValue);
   };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
-// src/App.tsx
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Deck } from "./models/types";
 import { deepCopyMasterTable } from "./models/masterData";
 import DeckTab from "./components/DeckTab";
@@ -8,12 +7,22 @@ import { Container, Typography, Button, Box } from "@mui/material";
 const App: React.FC = () => {
   const [decks, setDecks] = useState<Deck[]>([]);
 
+  useEffect(() => {
+    const savedDecks = localStorage.getItem("decks");
+    if (savedDecks) {
+      setDecks(JSON.parse(savedDecks));
+    }
+  }, []);
+
   const handleAddDeck = () => {
+    const deckName = prompt("Enter deck name:", "New Deck") || "New Deck";
     const newDeck: Deck = {
-      deckName: "New Deck",
+      deckName,
       factions: deepCopyMasterTable(),
     };
-    setDecks([...decks, newDeck]);
+    const updatedDecks = [...decks, newDeck];
+    setDecks(updatedDecks);
+    localStorage.setItem("decks", JSON.stringify(updatedDecks));
   };
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,11 @@ import React, { useState, useEffect } from "react";
 import { Deck } from "./models/types";
 import { deepCopyMasterTable } from "./models/masterData";
 import DeckTab from "./components/DeckTab";
-import { Container, Typography, Button, Box } from "@mui/material";
+import { Container, Typography, Button, Box, Tabs, Tab } from "@mui/material";
 
 const App: React.FC = () => {
   const [decks, setDecks] = useState<Deck[]>([]);
+  const [selectedTab, setSelectedTab] = useState(0);
 
   useEffect(() => {
     const savedDecks = localStorage.getItem("decks");
@@ -25,6 +26,10 @@ const App: React.FC = () => {
     localStorage.setItem("decks", JSON.stringify(updatedDecks));
   };
 
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setSelectedTab(newValue);
+  };
+
   return (
     <Container maxWidth={false}>
       <Typography variant="h4" gutterBottom>
@@ -34,9 +39,23 @@ const App: React.FC = () => {
         Add New Deck
       </Button>
 
+      <Tabs value={selectedTab} onChange={handleChange} aria-label="deck tabs">
+        {decks.map((deck, index) => (
+          <Tab key={index} label={deck.deckName} />
+        ))}
+      </Tabs>
+
       <Box>
         {decks.map((deck, index) => (
-          <DeckTab key={index} deck={deck} />
+          <div
+            role="tabpanel"
+            hidden={selectedTab !== index}
+            id={`tabpanel-${index}`}
+            aria-labelledby={`tab-${index}`}
+            key={index}
+          >
+            {selectedTab === index && <DeckTab deck={deck} />}
+          </div>
         ))}
       </Box>
     </Container>

--- a/src/components/DeckTab.tsx
+++ b/src/components/DeckTab.tsx
@@ -8,6 +8,9 @@ import {
   TableRow,
   Paper,
   Typography,
+  Tabs,
+  Tab,
+  Box,
 } from "@mui/material";
 import { Deck, Faction, Warlord } from "../models/types";
 
@@ -25,120 +28,151 @@ interface DeckTabProps {
 }
 
 const DeckTab: React.FC<DeckTabProps> = ({ deck }) => {
+  const [selectedTab, setSelectedTab] = React.useState(0);
+
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setSelectedTab(newValue);
+  };
+
   return (
     <Paper elevation={3} sx={{ p: 2, mb: 2 }}>
       <Typography variant="h5" gutterBottom>
         {deck.deckName}
       </Typography>
-      <TableContainer>
-        <Table size="small" aria-label="deck stats table">
-          <TableHead>
-            <TableRow>
-              <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
-                Faction
-              </TableCell>
-              <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
-                Warlord
-              </TableCell>
-              <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
-                Matches
-              </TableCell>
-              <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
-                Off. Wins
-              </TableCell>
-              <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
-                Off. Losses
-              </TableCell>
-              <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
-                Def. Wins
-              </TableCell>
-              <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
-                Def. Losses
-              </TableCell>
-              <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
-                Total Wins
-              </TableCell>
-              <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
-                Total Losses
-              </TableCell>
-              <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
-                Win Rate
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {deck.factions.map((faction: Faction) => {
-              const numberOfWarlords = faction.warlords.length;
-
-              return faction.warlords.map((warlord: Warlord, idx: number) => {
-                const { matches, totalWins, totalLosses, winRate } =
-                  getWarlordStats(warlord);
-
-                // Color-coded column styles
-                const offWinStyle = { backgroundColor: "#bfb" };
-                const offLossStyle = { backgroundColor: "#fbb" };
-                const defWinStyle = { backgroundColor: "#bfb" };
-                const defLossStyle = { backgroundColor: "#fbb" };
-                const totalWinStyle = { backgroundColor: "#dfd" };
-                const totalLossStyle = { backgroundColor: "#fdd" };
-                const rateStyle = { backgroundColor: "#eee" };
-
-                return (
-                  <TableRow
-                    key={`${faction.factionName}-${warlord.warlordName}`}
-                  >
-                    {/* 
-                      Only render the Faction cell for the first warlord in this faction 
-                      so it spans multiple rows. 
-                    */}
-                    {idx === 0 && (
+      <Tabs value={selectedTab} onChange={handleChange} aria-label="deck tabs">
+        {deck.factions.map((faction, index) => (
+          <Tab key={index} label={faction.factionName} />
+        ))}
+      </Tabs>
+      <Box>
+        {deck.factions.map((faction, index) => (
+          <div
+            role="tabpanel"
+            hidden={selectedTab !== index}
+            id={`tabpanel-${index}`}
+            aria-labelledby={`tab-${index}`}
+            key={index}
+          >
+            {selectedTab === index && (
+              <TableContainer>
+                <Table size="small" aria-label="deck stats table">
+                  <TableHead>
+                    <TableRow>
                       <TableCell
-                        rowSpan={numberOfWarlords}
-                        sx={{
-                          verticalAlign: "top",
-                          backgroundColor: "#cce",
-                          fontWeight: "bold",
-                        }}
+                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
                       >
-                        {faction.factionName}
+                        Warlord
                       </TableCell>
-                    )}
+                      <TableCell
+                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
+                      >
+                        Matches
+                      </TableCell>
+                      <TableCell
+                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
+                      >
+                        Off. Wins
+                      </TableCell>
+                      <TableCell
+                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
+                      >
+                        Off. Losses
+                      </TableCell>
+                      <TableCell
+                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
+                      >
+                        Def. Wins
+                      </TableCell>
+                      <TableCell
+                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
+                      >
+                        Def. Losses
+                      </TableCell>
+                      <TableCell
+                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
+                      >
+                        Total Wins
+                      </TableCell>
+                      <TableCell
+                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
+                      >
+                        Total Losses
+                      </TableCell>
+                      <TableCell
+                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
+                      >
+                        Win Rate
+                      </TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {faction.warlords.map((warlord: Warlord) => {
+                      const { matches, totalWins, totalLosses, winRate } =
+                        getWarlordStats(warlord);
 
-                    {/* Warlord Name */}
-                    <TableCell sx={{ backgroundColor: "#eef" }}>
-                      {warlord.warlordName}
-                    </TableCell>
+                      // Color-coded column styles
+                      const offWinStyle = { backgroundColor: "#bfb" };
+                      const offLossStyle = { backgroundColor: "#fbb" };
+                      const defWinStyle = { backgroundColor: "#bfb" };
+                      const defLossStyle = { backgroundColor: "#fbb" };
+                      const totalWinStyle = { backgroundColor: "#dfd" };
+                      const totalLossStyle = { backgroundColor: "#fdd" };
+                      const rateStyle = { backgroundColor: "#eee" };
 
-                    {/* Matches */}
-                    <TableCell>{matches}</TableCell>
+                      return (
+                        <TableRow key={warlord.warlordName}>
+                          {/* Warlord Name */}
+                          <TableCell sx={{ backgroundColor: "#eef" }}>
+                            {warlord.warlordName}
+                          </TableCell>
 
-                    {/* Off. Wins */}
-                    <TableCell sx={offWinStyle}>{warlord.offWins}</TableCell>
+                          {/* Matches */}
+                          <TableCell>{matches}</TableCell>
 
-                    {/* Off. Losses */}
-                    <TableCell sx={offLossStyle}>{warlord.offLosses}</TableCell>
+                          {/* Off. Wins */}
+                          <TableCell sx={offWinStyle}>
+                            {warlord.offWins}
+                          </TableCell>
 
-                    {/* Def. Wins */}
-                    <TableCell sx={defWinStyle}>{warlord.defWins}</TableCell>
+                          {/* Off. Losses */}
+                          <TableCell sx={offLossStyle}>
+                            {warlord.offLosses}
+                          </TableCell>
 
-                    {/* Def. Losses */}
-                    <TableCell sx={defLossStyle}>{warlord.defLosses}</TableCell>
+                          {/* Def. Wins */}
+                          <TableCell sx={defWinStyle}>
+                            {warlord.defWins}
+                          </TableCell>
 
-                    {/* Total Wins */}
-                    <TableCell sx={totalWinStyle}>{totalWins}</TableCell>
+                          {/* Def. Losses */}
+                          <TableCell sx={defLossStyle}>
+                            {warlord.defLosses}
+                          </TableCell>
 
-                    {/* Total Losses */}
-                    <TableCell sx={totalLossStyle}>{totalLosses}</TableCell>
+                          {/* Total Wins */}
+                          <TableCell sx={totalWinStyle}>
+                            {totalWins}
+                          </TableCell>
 
-                    {/* Win Rate */}
-                    <TableCell sx={rateStyle}>{winRate.toFixed(1)}%</TableCell>
-                  </TableRow>
-                );
-              });
-            })}
-          </TableBody>
-        </Table>
-      </TableContainer>
+                          {/* Total Losses */}
+                          <TableCell sx={totalLossStyle}>
+                            {totalLosses}
+                          </TableCell>
+
+                          {/* Win Rate */}
+                          <TableCell sx={rateStyle}>
+                            {winRate.toFixed(1)}%
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            )}
+          </div>
+        ))}
+      </Box>
     </Paper>
   );
 };

--- a/src/components/DeckTab.tsx
+++ b/src/components/DeckTab.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
   Box,
 } from "@mui/material";
-import { Deck, Warlord } from "../models/types";
+import { Deck, Warlord, Faction } from "../models/types";
 
 // Helper function to compute derived stats
 function getWarlordStats(w: Warlord) {
@@ -66,60 +66,60 @@ const DeckTab: React.FC<DeckTabProps> = ({ deck }) => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {deck.factions.flatMap((faction) =>
-                faction.warlords.map((warlord: Warlord) => {
-                  const { matches, totalWins, totalLosses, winRate } =
-                    getWarlordStats(warlord);
+              {deck.factions.map((faction: Faction) => (
+                <React.Fragment key={faction.factionName}>
+                  <TableRow>
+                    <TableCell colSpan={9} sx={{ backgroundColor: "#ddd", fontWeight: "bold" }}>
+                      {faction.factionName}
+                    </TableCell>
+                  </TableRow>
+                  {faction.warlords.map((warlord: Warlord) => {
+                    const { matches, totalWins, totalLosses, winRate } = getWarlordStats(warlord);
 
-                  // Color-coded column styles
-                  const offWinStyle = { backgroundColor: "#bfb" };
-                  const offLossStyle = { backgroundColor: "#fbb" };
-                  const defWinStyle = { backgroundColor: "#bfb" };
-                  const defLossStyle = { backgroundColor: "#fbb" };
-                  const totalWinStyle = { backgroundColor: "#dfd" };
-                  const totalLossStyle = { backgroundColor: "#fdd" };
-                  const rateStyle = { backgroundColor: "#eee" };
+                    // Color-coded column styles
+                    const offWinStyle = { backgroundColor: "#bfb" };
+                    const offLossStyle = { backgroundColor: "#fbb" };
+                    const defWinStyle = { backgroundColor: "#bfb" };
+                    const defLossStyle = { backgroundColor: "#fbb" };
+                    const totalWinStyle = { backgroundColor: "#dfd" };
+                    const totalLossStyle = { backgroundColor: "#fdd" };
+                    const rateStyle = { backgroundColor: "#eee" };
 
-                  return (
-                    <TableRow key={warlord.warlordName}>
-                      {/* Warlord Name */}
-                      <TableCell sx={{ backgroundColor: "#eef" }}>
-                        {warlord.warlordName}
-                      </TableCell>
+                    return (
+                      <TableRow key={warlord.warlordName}>
+                        {/* Warlord Name */}
+                        <TableCell sx={{ backgroundColor: "#eef" }}>
+                          {warlord.warlordName}
+                        </TableCell>
 
-                      {/* Matches */}
-                      <TableCell>{matches}</TableCell>
+                        {/* Matches */}
+                        <TableCell>{matches}</TableCell>
 
-                      {/* Off. Wins */}
-                      <TableCell sx={offWinStyle}>{warlord.offWins}</TableCell>
+                        {/* Off. Wins */}
+                        <TableCell sx={offWinStyle}>{warlord.offWins}</TableCell>
 
-                      {/* Off. Losses */}
-                      <TableCell sx={offLossStyle}>
-                        {warlord.offLosses}
-                      </TableCell>
+                        {/* Off. Losses */}
+                        <TableCell sx={offLossStyle}>{warlord.offLosses}</TableCell>
 
-                      {/* Def. Wins */}
-                      <TableCell sx={defWinStyle}>{warlord.defWins}</TableCell>
+                        {/* Def. Wins */}
+                        <TableCell sx={defWinStyle}>{warlord.defWins}</TableCell>
 
-                      {/* Def. Losses */}
-                      <TableCell sx={defLossStyle}>
-                        {warlord.defLosses}
-                      </TableCell>
+                        {/* Def. Losses */}
+                        <TableCell sx={defLossStyle}>{warlord.defLosses}</TableCell>
 
-                      {/* Total Wins */}
-                      <TableCell sx={totalWinStyle}>{totalWins}</TableCell>
+                        {/* Total Wins */}
+                        <TableCell sx={totalWinStyle}>{totalWins}</TableCell>
 
-                      {/* Total Losses */}
-                      <TableCell sx={totalLossStyle}>{totalLosses}</TableCell>
+                        {/* Total Losses */}
+                        <TableCell sx={totalLossStyle}>{totalLosses}</TableCell>
 
-                      {/* Win Rate */}
-                      <TableCell sx={rateStyle}>
-                        {winRate.toFixed(1)}%
-                      </TableCell>
-                    </TableRow>
-                  );
-                })
-              )}
+                        {/* Win Rate */}
+                        <TableCell sx={rateStyle}>{winRate.toFixed(1)}%</TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </React.Fragment>
+              ))}
             </TableBody>
           </Table>
         </TableContainer>

--- a/src/components/DeckTab.tsx
+++ b/src/components/DeckTab.tsx
@@ -8,11 +8,9 @@ import {
   TableRow,
   Paper,
   Typography,
-  Tabs,
-  Tab,
   Box,
 } from "@mui/material";
-import { Deck, Faction, Warlord } from "../models/types";
+import { Deck, Warlord } from "../models/types";
 
 // Helper function to compute derived stats
 function getWarlordStats(w: Warlord) {
@@ -28,150 +26,103 @@ interface DeckTabProps {
 }
 
 const DeckTab: React.FC<DeckTabProps> = ({ deck }) => {
-  const [selectedTab, setSelectedTab] = React.useState(0);
-
-  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
-    setSelectedTab(newValue);
-  };
-
   return (
     <Paper elevation={3} sx={{ p: 2, mb: 2 }}>
       <Typography variant="h5" gutterBottom>
         {deck.deckName}
       </Typography>
-      <Tabs value={selectedTab} onChange={handleChange} aria-label="deck tabs">
-        {deck.factions.map((faction, index) => (
-          <Tab key={index} label={faction.factionName} />
-        ))}
-      </Tabs>
       <Box>
-        {deck.factions.map((faction, index) => (
-          <div
-            role="tabpanel"
-            hidden={selectedTab !== index}
-            id={`tabpanel-${index}`}
-            aria-labelledby={`tab-${index}`}
-            key={index}
-          >
-            {selectedTab === index && (
-              <TableContainer>
-                <Table size="small" aria-label="deck stats table">
-                  <TableHead>
-                    <TableRow>
-                      <TableCell
-                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
-                      >
-                        Warlord
+        <TableContainer>
+          <Table size="small" aria-label="deck stats table">
+            <TableHead>
+              <TableRow>
+                <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
+                  Warlord
+                </TableCell>
+                <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
+                  Matches
+                </TableCell>
+                <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
+                  Off. Wins
+                </TableCell>
+                <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
+                  Off. Losses
+                </TableCell>
+                <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
+                  Def. Wins
+                </TableCell>
+                <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
+                  Def. Losses
+                </TableCell>
+                <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
+                  Total Wins
+                </TableCell>
+                <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
+                  Total Losses
+                </TableCell>
+                <TableCell sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}>
+                  Win Rate
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {deck.factions.flatMap((faction) =>
+                faction.warlords.map((warlord: Warlord) => {
+                  const { matches, totalWins, totalLosses, winRate } =
+                    getWarlordStats(warlord);
+
+                  // Color-coded column styles
+                  const offWinStyle = { backgroundColor: "#bfb" };
+                  const offLossStyle = { backgroundColor: "#fbb" };
+                  const defWinStyle = { backgroundColor: "#bfb" };
+                  const defLossStyle = { backgroundColor: "#fbb" };
+                  const totalWinStyle = { backgroundColor: "#dfd" };
+                  const totalLossStyle = { backgroundColor: "#fdd" };
+                  const rateStyle = { backgroundColor: "#eee" };
+
+                  return (
+                    <TableRow key={warlord.warlordName}>
+                      {/* Warlord Name */}
+                      <TableCell sx={{ backgroundColor: "#eef" }}>
+                        {warlord.warlordName}
                       </TableCell>
-                      <TableCell
-                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
-                      >
-                        Matches
+
+                      {/* Matches */}
+                      <TableCell>{matches}</TableCell>
+
+                      {/* Off. Wins */}
+                      <TableCell sx={offWinStyle}>{warlord.offWins}</TableCell>
+
+                      {/* Off. Losses */}
+                      <TableCell sx={offLossStyle}>
+                        {warlord.offLosses}
                       </TableCell>
-                      <TableCell
-                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
-                      >
-                        Off. Wins
+
+                      {/* Def. Wins */}
+                      <TableCell sx={defWinStyle}>{warlord.defWins}</TableCell>
+
+                      {/* Def. Losses */}
+                      <TableCell sx={defLossStyle}>
+                        {warlord.defLosses}
                       </TableCell>
-                      <TableCell
-                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
-                      >
-                        Off. Losses
-                      </TableCell>
-                      <TableCell
-                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
-                      >
-                        Def. Wins
-                      </TableCell>
-                      <TableCell
-                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
-                      >
-                        Def. Losses
-                      </TableCell>
-                      <TableCell
-                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
-                      >
-                        Total Wins
-                      </TableCell>
-                      <TableCell
-                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
-                      >
-                        Total Losses
-                      </TableCell>
-                      <TableCell
-                        sx={{ backgroundColor: "#ccc", fontWeight: "bold" }}
-                      >
-                        Win Rate
+
+                      {/* Total Wins */}
+                      <TableCell sx={totalWinStyle}>{totalWins}</TableCell>
+
+                      {/* Total Losses */}
+                      <TableCell sx={totalLossStyle}>{totalLosses}</TableCell>
+
+                      {/* Win Rate */}
+                      <TableCell sx={rateStyle}>
+                        {winRate.toFixed(1)}%
                       </TableCell>
                     </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {faction.warlords.map((warlord: Warlord) => {
-                      const { matches, totalWins, totalLosses, winRate } =
-                        getWarlordStats(warlord);
-
-                      // Color-coded column styles
-                      const offWinStyle = { backgroundColor: "#bfb" };
-                      const offLossStyle = { backgroundColor: "#fbb" };
-                      const defWinStyle = { backgroundColor: "#bfb" };
-                      const defLossStyle = { backgroundColor: "#fbb" };
-                      const totalWinStyle = { backgroundColor: "#dfd" };
-                      const totalLossStyle = { backgroundColor: "#fdd" };
-                      const rateStyle = { backgroundColor: "#eee" };
-
-                      return (
-                        <TableRow key={warlord.warlordName}>
-                          {/* Warlord Name */}
-                          <TableCell sx={{ backgroundColor: "#eef" }}>
-                            {warlord.warlordName}
-                          </TableCell>
-
-                          {/* Matches */}
-                          <TableCell>{matches}</TableCell>
-
-                          {/* Off. Wins */}
-                          <TableCell sx={offWinStyle}>
-                            {warlord.offWins}
-                          </TableCell>
-
-                          {/* Off. Losses */}
-                          <TableCell sx={offLossStyle}>
-                            {warlord.offLosses}
-                          </TableCell>
-
-                          {/* Def. Wins */}
-                          <TableCell sx={defWinStyle}>
-                            {warlord.defWins}
-                          </TableCell>
-
-                          {/* Def. Losses */}
-                          <TableCell sx={defLossStyle}>
-                            {warlord.defLosses}
-                          </TableCell>
-
-                          {/* Total Wins */}
-                          <TableCell sx={totalWinStyle}>
-                            {totalWins}
-                          </TableCell>
-
-                          {/* Total Losses */}
-                          <TableCell sx={totalLossStyle}>
-                            {totalLosses}
-                          </TableCell>
-
-                          {/* Win Rate */}
-                          <TableCell sx={rateStyle}>
-                            {winRate.toFixed(1)}%
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-            )}
-          </div>
-        ))}
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
       </Box>
     </Paper>
   );

--- a/src/components/DeckTab.tsx
+++ b/src/components/DeckTab.tsx
@@ -69,12 +69,16 @@ const DeckTab: React.FC<DeckTabProps> = ({ deck }) => {
               {deck.factions.map((faction: Faction) => (
                 <React.Fragment key={faction.factionName}>
                   <TableRow>
-                    <TableCell colSpan={9} sx={{ backgroundColor: "#ddd", fontWeight: "bold" }}>
+                    <TableCell
+                      colSpan={9}
+                      sx={{ backgroundColor: "#ddd", fontWeight: "bold" }}
+                    >
                       {faction.factionName}
                     </TableCell>
                   </TableRow>
                   {faction.warlords.map((warlord: Warlord) => {
-                    const { matches, totalWins, totalLosses, winRate } = getWarlordStats(warlord);
+                    const { matches, totalWins, totalLosses, winRate } =
+                      getWarlordStats(warlord);
 
                     // Color-coded column styles
                     const offWinStyle = { backgroundColor: "#bfb" };
@@ -96,16 +100,24 @@ const DeckTab: React.FC<DeckTabProps> = ({ deck }) => {
                         <TableCell>{matches}</TableCell>
 
                         {/* Off. Wins */}
-                        <TableCell sx={offWinStyle}>{warlord.offWins}</TableCell>
+                        <TableCell sx={offWinStyle}>
+                          {warlord.offWins}
+                        </TableCell>
 
                         {/* Off. Losses */}
-                        <TableCell sx={offLossStyle}>{warlord.offLosses}</TableCell>
+                        <TableCell sx={offLossStyle}>
+                          {warlord.offLosses}
+                        </TableCell>
 
                         {/* Def. Wins */}
-                        <TableCell sx={defWinStyle}>{warlord.defWins}</TableCell>
+                        <TableCell sx={defWinStyle}>
+                          {warlord.defWins}
+                        </TableCell>
 
                         {/* Def. Losses */}
-                        <TableCell sx={defLossStyle}>{warlord.defLosses}</TableCell>
+                        <TableCell sx={defLossStyle}>
+                          {warlord.defLosses}
+                        </TableCell>
 
                         {/* Total Wins */}
                         <TableCell sx={totalWinStyle}>{totalWins}</TableCell>
@@ -114,7 +126,9 @@ const DeckTab: React.FC<DeckTabProps> = ({ deck }) => {
                         <TableCell sx={totalLossStyle}>{totalLosses}</TableCell>
 
                         {/* Win Rate */}
-                        <TableCell sx={rateStyle}>{winRate.toFixed(1)}%</TableCell>
+                        <TableCell sx={rateStyle}>
+                          {winRate.toFixed(1)}%
+                        </TableCell>
                       </TableRow>
                     );
                   })}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adobe/css-tools@^4.4.0":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.2.tgz#c836b1bd81e6d62cd6cdf3ee4948bcdce8ea79c8"
+  integrity sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==
+
 "@ampproject/remapping@^2.2.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
@@ -1134,6 +1139,19 @@
     lz-string "^1.5.0"
     pretty-format "^27.0.2"
 
+"@testing-library/jest-dom@^6.6.3":
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz#26ba906cf928c0f8172e182c6fe214eb4f9f2bd2"
+  integrity sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==
+  dependencies:
+    "@adobe/css-tools" "^4.4.0"
+    aria-query "^5.0.0"
+    chalk "^3.0.0"
+    css.escape "^1.5.1"
+    dom-accessibility-api "^0.6.3"
+    lodash "^4.17.21"
+    redent "^3.0.0"
+
 "@testing-library/react@^16.2.0":
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.2.0.tgz#c96126ee01a49cdb47175721911b4a9432afc601"
@@ -1521,6 +1539,11 @@ aria-query@5.3.0:
   dependencies:
     dequal "^2.0.3"
 
+aria-query@^5.0.0:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
+  integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
+
 array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz#384d12a37295aec3769ab022ad323a18a51ccf8b"
@@ -1798,6 +1821,14 @@ caniuse-lite@^1.0.30001688:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz#26cd429cf09b4fd4e745daf4916039c794d720f6"
   integrity sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -1930,6 +1961,11 @@ css-to-react-native@3.2.0:
     camelize "^1.0.0"
     css-color-keywords "^1.0.0"
     postcss-value-parser "^4.0.2"
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
 
 cssom@^0.5.0:
   version "0.5.0"
@@ -2070,6 +2106,11 @@ dom-accessibility-api@^0.5.9:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
+dom-accessibility-api@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
+  integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
 dom-helpers@^5.0.1:
   version "5.2.1"
@@ -2841,6 +2882,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -3674,6 +3720,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -3751,6 +3802,11 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
@@ -4156,6 +4212,14 @@ react@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-19.0.0.tgz#6e1969251b9f108870aa4bff37a0ce9ddfaaabdd"
   integrity sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
@@ -4563,6 +4627,13 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Fixes #1

Add functionality to create and manage decks with unique names, save to local storage, and switch between decks using tabs.

* **src/App.tsx**
  - Add a prompt to ask the user for a deck name when creating a new deck.
  - Assign a default name "New Deck" if the user does not provide a name.
  - Save the new deck to local storage using `localStorage.setItem`.
  - Load decks from local storage on component mount using `localStorage.getItem`.

* **src/components/DeckTab.tsx**
  - Add tabs for each deck for quick switching.
  - Display deck stats in a tabbed interface.

* **src/App.spec.tsx**
  - Add tests for creating a new deck with a unique name.
  - Add tests for saving the deck to local storage.
  - Add tests for loading decks from local storage on component mount.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/acezard/warpforge-tracker/pull/15?shareId=de841408-2f46-48a6-913f-2806750b3d92).